### PR TITLE
Update action.py : Redirect Docker command output to prevent Python hang

### DIFF
--- a/app/modules/service/action.py
+++ b/app/modules/service/action.py
@@ -57,7 +57,7 @@ def get_action_command(service: str, action: str, server_id: int) -> str:
         container_name = sql.get_setting(f'{service}_container_name')
         if action == 'reload':
             action = 'kill -s HUP'
-        commands = f"sudo docker {action} {container_name}"
+        commands = f"sudo docker {action} {container_name} > /dev/null"
     else:
         service_name = service_common.get_correct_service_name(service, server_id)
         commands = f"sudo systemctl {action} {service_name}"


### PR DESCRIPTION
When executing Docker commands via Python, such as `docker kill -s HUP <container>`, the process may hang because the command produces output that blocks the Python subprocess.  

This change appends `> /dev/null` to Docker commands to discard any standard output, ensuring that Python can execute the command without waiting indefinitely.  

Systemd commands remain unchanged, as they do not exhibit the same blocking behavior.